### PR TITLE
fixes findDefaultBusinessUnitByCompanyId() function if no entity was found in the query

### DIFF
--- a/src/Spryker/Zed/CompanyBusinessUnit/Persistence/CompanyBusinessUnitRepository.php
+++ b/src/Spryker/Zed/CompanyBusinessUnit/Persistence/CompanyBusinessUnitRepository.php
@@ -123,6 +123,10 @@ class CompanyBusinessUnitRepository extends AbstractRepository implements Compan
 
         $entityTransfer = $this->buildQueryFromCriteria($query)->findOne();
 
+        if (!$entityTransfer) {
+            return null;
+        }
+
         return $this->getFactory()
             ->createCompanyBusinessUnitMapper()
             ->mapEntityTransferToBusinessUnitTransfer($entityTransfer, new CompanyBusinessUnitTransfer());


### PR DESCRIPTION
## PR Description

if the repository function `findDefaultBusinessUnitByCompanyId()` does not find any entity, there will be an exception in the mapping of the result - so the query result `null` needs to be returned immediately.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
