### PR TITLE
Bugfix: use modifiedToArray instead of toArray

### DIFF
--- a/src/Spryker/Zed/CompanyBusinessUnit/Persistence/Propel/Mapper/CompanyBusinessUnitMapper.php
+++ b/src/Spryker/Zed/CompanyBusinessUnit/Persistence/Propel/Mapper/CompanyBusinessUnitMapper.php
@@ -82,7 +82,7 @@ class CompanyBusinessUnitMapper implements CompanyBusinessUnitMapperInterface
         CompanyBusinessUnitTransfer $companyBusinessUnitTransfer,
         SpyCompanyBusinessUnit $companyBusinessUnitEntity
     ): SpyCompanyBusinessUnit {
-        return $companyBusinessUnitEntity->fromArray($companyBusinessUnitTransfer->toArray());
+        return $companyBusinessUnitEntity->fromArray($companyBusinessUnitTransfer->modifiedToArray());
     }
 
     /**


### PR DESCRIPTION
## PR Description

With the new CompanyBusinessUnitEntityManager->updateCompanyBusinessUnit() function some updates like default billing address is broken. The function below in the CompanyUnitAddress package for example maps only the id and default billing on the CompanyBusinessUnitTransfer. 


    protected function updateBusinessUnitDefaultAddresses(
        CompanyUnitAddressTransfer $companyUnitAddressTransfer
    ): void {
        ...
            $companyBusinessUnitTransfer = new CompanyBusinessUnitTransfer();
            $companyBusinessUnitTransfer
                ->setIdCompanyBusinessUnit($companyUnitAddressTransfer->getFkCompanyBusinessUnit())
                ->setDefaultBillingAddress($companyUnitAddressTransfer->getIdCompanyUnitAddress());

           ...
        }
    }

The new updateCompanyBusinessUnit() function fetches the companyBusinessUnit from DB and in the mapper the entity data will be overwritten with only the id and billing address, since fromArray toArray is used instead of modifiedToArray. This rises an exception since required data is missing

## Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
