### PR TITLE
Replaced CompanyBusinessUnitTransfer object to preserve mapping data

### DIFF
--- a/src/Spryker/Zed/CompanyBusinessUnit/Persistence/CompanyBusinessUnitEntityManager.php
+++ b/src/Spryker/Zed/CompanyBusinessUnit/Persistence/CompanyBusinessUnitEntityManager.php
@@ -115,7 +115,7 @@ class CompanyBusinessUnitEntityManager extends AbstractEntityManager implements 
 
         return $this->getMapper()->mapCompanyBusinessUnitEntityToCompanyBusinessUnitTransfer(
             $companyBusinessUnitEntity,
-            new CompanyBusinessUnitTransfer(),
+            $companyBusinessUnitTransfer,
         );
     }
 


### PR DESCRIPTION
## PR Description

In the release changes from [2.15.1 to 2.16.0](https://github.com/spryker/company-business-unit/compare/2.15.1...2.16.0), a new method `CompanyBusinessUnitEntityManagerInterface::updateCompanyBusinessUnit` was introduced. This method has an issue where related data, such as AddressCollection, is lost when using the `\Spryker\Zed\CompanyBusinessUnitExtension\Dependency\Plugin\CompanyBusinessUnitPostSavePluginInterface` plugin stack.

To address this issue, the proposed fix replaces the newly created `CompanyBusinessUnitTransfer` object with the original one passed into the update function. This ensures that all related data is retained during the update process.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
